### PR TITLE
Add plugin fixing Android dark mode detection

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-status-bar')
+    implementation project(':robingenz-capacitor-android-dark-mode-support')
 
 }
 

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -22,5 +22,9 @@
 	{
 		"pkg": "@capacitor/status-bar",
 		"classpath": "com.capacitorjs.plugins.statusbar.StatusBarPlugin"
+	},
+	{
+		"pkg": "@robingenz/capacitor-android-dark-mode-support",
+		"classpath": "dev.robingenz.capacitor.androiddarkmodesupport.AndroidDarkModeSupportPlugin"
 	}
 ]

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -19,3 +19,6 @@ project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor
 
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+
+include ':robingenz-capacitor-android-dark-mode-support'
+project(':robingenz-capacitor-android-dark-mode-support').projectDir = new File('../node_modules/@robingenz/capacitor-android-dark-mode-support/android')

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@ionic-native/core": "^5.31.1",
         "@ionic/angular": "^6.0.0",
         "@ionic/storage-angular": "^3.0.2",
+        "@robingenz/capacitor-android-dark-mode-support": "^1.0.0",
         "@webful/passwordmaker-lib": "~0.1.2",
         "2ldcheck": "~0.0.6",
         "capacitor-resources": "^2.0.5",
@@ -3712,6 +3713,14 @@
         "@npmcli/promise-spawn": "^1.3.2",
         "node-gyp": "^8.2.0",
         "read-package-json-fast": "^2.0.1"
+      }
+    },
+    "node_modules/@robingenz/capacitor-android-dark-mode-support": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@robingenz/capacitor-android-dark-mode-support/-/capacitor-android-dark-mode-support-1.0.0.tgz",
+      "integrity": "sha512-QlldCPzqODpyud4bJJ1h6/3t/umD/N4xu86uenlxMLUOGg8miZEEoTs8HjPdTEb/U3lryx4Et1R5LVHFYguCuw==",
+      "peerDependencies": {
+        "@capacitor/core": "^3.0.0-rc.0"
       }
     },
     "node_modules/@schematics/angular": {
@@ -22485,6 +22494,12 @@
         "node-gyp": "^8.2.0",
         "read-package-json-fast": "^2.0.1"
       }
+    },
+    "@robingenz/capacitor-android-dark-mode-support": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@robingenz/capacitor-android-dark-mode-support/-/capacitor-android-dark-mode-support-1.0.0.tgz",
+      "integrity": "sha512-QlldCPzqODpyud4bJJ1h6/3t/umD/N4xu86uenlxMLUOGg8miZEEoTs8HjPdTEb/U3lryx4Et1R5LVHFYguCuw==",
+      "requires": {}
     },
     "@schematics/angular": {
       "version": "12.2.14",

--- a/package.json.dist
+++ b/package.json.dist
@@ -36,6 +36,7 @@
     "@ionic-native/core": "^5.31.1",
     "@ionic/angular": "^6.0.0",
     "@ionic/storage-angular": "^3.0.2",
+    "@robingenz/capacitor-android-dark-mode-support": "^1.0.0",
     "@webful/passwordmaker-lib": "~0.1.2",
     "2ldcheck": "~0.0.6",
     "capacitor-resources": "^2.0.5",


### PR DESCRIPTION
Fixes #23

This method with [this plugin](https://github.com/robingenz/capacitor-android-dark-mode-support) seems to be far easier and actually work, whereas the other branch method and article didn't on Capacitor 3+. It looks to take a similar approach to the workarounds on https://github.com/ionic-team/capacitor/discussions/1978 while doing it for us.